### PR TITLE
fix(hoisting): allow hoisted functions to be used before being defined

### DIFF
--- a/packages/node_modules/@ciscospark/eslint-config-base/rules/variables.js
+++ b/packages/node_modules/@ciscospark/eslint-config-base/rules/variables.js
@@ -37,6 +37,6 @@ module.exports = {
     'no-unused-vars': ['error', {vars: 'all', args: 'after-used', ignoreRestSiblings: true}],
 
     // disallow use of variables before they are defined
-    'no-use-before-define': ['error', {functions: true, classes: true, variables: true}]
+    'no-use-before-define': ['error', {functions: false, classes: false, variables: true}]
   }
 };


### PR DESCRIPTION
`no-use-before-define` is great to prevent confusing use of hoisted variables, but it's pretty common to but the meat of a a file at the top and then define helper functions at the bottom out of the way. Moreover, circular-ish dependencies caused by event-based programming often make it difficult to completely avoid using a function before it's defined. I'm ambivalent on classes, but they seem more like functions that variables.