### PR TITLE
feat(valid-jsdoc): do not require `@return` for non-returning functions

### DIFF
--- a/packages/node_modules/@ciscospark/eslint-config-base/rules/errors.js
+++ b/packages/node_modules/@ciscospark/eslint-config-base/rules/errors.js
@@ -128,7 +128,7 @@ module.exports = {
           fires: 'emits'
         },
         requireParamDescription: false,
-        requireReturn: true,
+        requireReturn: false,
         requireReturnType: true,
         requireReturnDescription: false
       }


### PR DESCRIPTION
Fixes #5